### PR TITLE
Update baam's URL

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -120,7 +120,7 @@ const externalItems: Item[] = [
   },
   {
     title: "Baam",
-    path: "https://baam.duckdns.org/s",
+    path: "https://baam.tatar/s",
     icon: (
       <span className="icon-[material-symbols--qr-code-rounded] text-4xl" />
     ),


### PR DESCRIPTION
NOTE: I am the current maintainer of baam.

### Description of changes

The baam is currently migrating to another domain. Currently baam.duckdns.org and baam.tatar are both functional, but the latter is gonna be the preferred domain. Using it will also solve some problems with baam availability due to duckdns infrastructure being flaky