### PR TITLE
fix: current time calculation with different timezone

### DIFF
--- a/src/components/calendar/CalendarViewer.tsx
+++ b/src/components/calendar/CalendarViewer.tsx
@@ -103,8 +103,44 @@ export default function CalendarViewer({
             }
           }
         }}
+        eventDataTransform={(input) => {
+          // Dates have Europe/Moscow timezone,
+          // but the sources doesn't set timezones,
+          // so the local zone is set
+          if (typeof input.start == "string") {
+            if (
+              !input.start.match(/Z\+/g)?.length &&
+              (input.start.match(/-/g)?.length || 0) <= 2
+            ) {
+              input.start = new Date(input.start + "+03:00");
+            }
+          }
+
+          if (typeof input.end == "string") {
+            if (
+              !input.end.match(/Z\+/g)?.length &&
+              (input.end.match(/-/g)?.length || 0) <= 2
+            ) {
+              input.end = new Date(input.end + "+03:00");
+            }
+          }
+
+          if (input.start instanceof Date) {
+            input.start = new Date(
+              Number(input.start) - input.start.getTimezoneOffset() * 60 * 1000,
+            );
+          }
+
+          if (input.end instanceof Date) {
+            input.end = new Date(
+              Number(input.end) - input.end.getTimezoneOffset() * 60 * 1000,
+            );
+          }
+
+          return input;
+        }}
         progressiveEventRendering={true}
-        timeZone="Europe/Moscow" // Use the same timezone for everyone
+        timeZone="UTC+0" // Use the same timezone for everyone
         plugins={[
           momentPlugin,
           dayGridPlugin,
@@ -202,9 +238,9 @@ export default function CalendarViewer({
           )
             return null; // It's a line, not a label
           // Fix timezone
-          const text = moment(Number(arg.date) - 3 * 60 * 60 * 1000).format(
-            "HH:mm",
-          );
+          const text = moment(
+            Number(arg.date) + arg.date.getTimezoneOffset() * 60 * 1000,
+          ).format("HH:mm");
           const isNearTimeLabel =
             arg.date.getUTCMinutes() < 15 || arg.date.getUTCMinutes() > 45;
           if (!isNearTimeLabel) {


### PR DESCRIPTION
Reported-by @peplxx on github
Fixes #229

### Description of changes
- Make sure that any date from the sources have a timezone (the default time zone is UTC+3).
- Set UTC+0 timezone in calendarfull
- Make sure that the current time line shows the correct time in the different time zones.